### PR TITLE
Update request responses

### DIFF
--- a/tests/test_webservice.py
+++ b/tests/test_webservice.py
@@ -15,7 +15,7 @@ def test_fn_registration_invalid():
                          json={"name": "hello",
                                "payload": "payload"})
 
-    assert resp.status_code == 500
+    assert resp.status_code in [500, 400]
 
 
 def double(x):
@@ -29,7 +29,7 @@ def test_fn_registration():
                          json={"name": "double",
                                "payload": serialized_fn})
 
-    assert resp.status_code == 200 or resp.status_code == 201
+    assert resp.status_code in [200, 201]
     assert "function_id" in resp.json()
 
 
@@ -68,7 +68,7 @@ def test_roundtrip():
                          json={"function_id": fn_info['function_id'],
                                "payload": serialize(((number,), {}))})
 
-    assert resp.status_code == 200 or resp.status_code == 201
+    assert resp.status_code in [200, 201]
     assert "task_id" in resp.json()
 
     task_id = resp.json()["task_id"]


### PR DESCRIPTION
Added potential `400` response to `test_fn_registration_invalid` and used `in` syntax instead of `or`.